### PR TITLE
Chore | Use version library to manage checker framework

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,5 +8,12 @@ repositories {
 }
 
 dependencies {
-    implementation("org.checkerframework:checkerframework-gradle-plugin:0.6.55")
+    // implementation("org.checkerframework:checkerframework-gradle-plugin:0.6.55")
+    implementation(plugin(libs.plugins.checkerframework))
+}
+
+// Helper function that transforms a Gradle Plugin alias from a
+// Version Catalog into a valid dependency notation for buildSrc
+fun DependencyHandlerScope.plugin(plugin: Provider<PluginDependency>) = plugin.map { 
+    "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version}" 
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,6 @@ repositories {
 }
 
 dependencies {
-    // implementation("org.checkerframework:checkerframework-gradle-plugin:0.6.55")
     implementation(plugin(libs.plugins.checkerframework))
 }
 

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,8 @@
+// Add the version catalog to buildSrc using dependencyResolutionManagement
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -112,20 +112,25 @@ if (strictMode) {
 // Checker Framework configuration
 
 val checker by extra { findProperty("checker") == "true" }
-val checkerVersion by extra("3.45.0")
+
+val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+
+var checkerMain = libs.findLibrary("checker.main").get()
+var checkerQual = libs.findLibrary("checker.qual").get()
+var checkerUtil = libs.findLibrary("checker.util").get()
 
 dependencies {
-    compileOnly("org.checkerframework:checker-qual:$checkerVersion")
-    testFixturesImplementation("org.checkerframework:checker-qual:$checkerVersion")
-    implementation("org.checkerframework:checker-util:$checkerVersion")
-    checkerFramework("org.checkerframework:checker:$checkerVersion")
+    compileOnly(checkerQual)
+    testFixturesImplementation(checkerQual)
+    implementation(checkerUtil)
+    checkerFramework(checkerMain)
 }
 
 testing {
     suites { 
         withType(JvmTestSuite::class).configureEach { 
             dependencies {
-                compileOnly("org.checkerframework:checker-qual:$checkerVersion")
+                compileOnly(checkerQual)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,3 +16,4 @@ osgi-annotation = { module = "org.osgi:osgi.annotation", version = "8.1.0" }
 springboot = { id = "org.springframework.boot", version = "3.5.0" }
 tasktree = { id = "com.dorongold.task-tree", version = "4.0.1" }
 cyclonedx = { id = "org.cyclonedx.bom", version = "2.2.0" }
+checkerframework = { id = "org.checkerframework", version = "0.6.55" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 resilience4j = "2.3.0"
+checkerframework = "3.45.0"
 
 [libraries]
 google-oauth-client = { module = "com.google.oauth-client:google-oauth-client-jetty", version = "1.39.0" }
@@ -7,6 +8,9 @@ google-api-directory = { module = "com.google.apis:google-api-services-admin-dir
 apache-commons-collections = { module = "org.apache.commons:commons-collections4", version = "4.4" }
 otel-logs-autoconfigure = { module = "am.ik.spring.opentelemetry:otel-logs-autoconfigure", version = "0.3.0" }
 resilience4j-ratelimiter = { module = "io.github.resilience4j:resilience4j-ratelimiter", version.ref = "resilience4j" }
+checker-main = { module = "org.checkerframework:checker", version.ref = "checkerframework" }
+checker-util = { module = "org.checkerframework:checker-util", version.ref = "checkerframework" }
+checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checkerframework" }
 # For getting rid of annotation warnings
 spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version = "4.9.3" }
 bnd-annotation = { module = "biz.aQute.bnd:biz.aQute.bnd.annotation", version = "7.1.0" }


### PR DESCRIPTION
Involves some tricks to access it in `buildSrc`