### PR TITLE
Chore | Update PR Checks workflows to cancel in progress

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -11,7 +11,10 @@ on:
     types:
       - checks_requested
 
-concurrency: pr-${{ github.ref }}
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Build


### PR DESCRIPTION
For a PR, all that matters anyway is the latest commit. So if more commits were added, just cancel any still running workflow on the previous commits to save on Actions runtime.